### PR TITLE
CAPEC ID Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Staged in Develop
 ## Improvements
 - Added support for ATT&CK Workbench as a datasource
+- Added parsing for CAPEC IDs in AttackToExcel
 
 # v1.4.0 - 10/21/2021
 ## Fixes

--- a/mitreattack/attackToExcel/stixToDf.py
+++ b/mitreattack/attackToExcel/stixToDf.py
@@ -160,6 +160,10 @@ def techniquesToDf(src, domain):
                 row["supports remote"] = technique["x_mitre_remote_support"]
             if "impact" in tactic_shortnames and "x_mitre_impact_type" in technique:
                 row["impact type"] = ", ".join(sorted(technique["x_mitre_impact_type"]))
+            capec_refs = list(filter(lambda ref: ref["source_name"] == "capec",
+                                     technique["external_references"]))
+            if capec_refs:
+                row["CAPEC ID"] = capec_refs[0]["external_id"]
 
         # domain specific fields -- mobile
         elif domain == "mobile-attack":


### PR DESCRIPTION
Adds processing and parsing for CAPEC IDs within AttackToExcel. This processing only applies to Enterprise datasets.

Closes #43