### PR TITLE
Parse citations out of relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added support for ATT&CK Workbench as a datasource
 - Added parsing for CAPEC IDs in AttackToExcel
 - Added support for data sources and data components when generating layers
+- Added parsing for relationship references/citations in AttackToExcel
 
 # v1.4.0 - 10/21/2021
 ## Fixes


### PR DESCRIPTION
Allows attackToExcel to extract citations from relationships, providing a more complete collection of citations in the generated spreadsheets.

Addresses #47 