### PR TITLE
Fixes Technique Parsing for Tactic Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Staged in Develop
 ## Fixes
 - Fixed tactic parsing in AttackToExcel so tactics are capitalized correctly in the output (Command and Control instead of Command And Control)
+- Corrected minor mistakes in the README documentation of some cli scripts
 
 # v1.4.2 - 1/11/2022
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Staged in Develop
+## Fixes
+- Fixed tactic parsing in AttackToExcel so tactics are capitalized correctly in the output (Command and Control instead of Command And Control)
+
 # v1.4.2 - 1/11/2022
 ## Improvements
 - Added support for multiple CAPEC IDs for a single technique in AttackToExcel

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ lay = Layer()
 lay.from_file("path/to/layer/example.json")           # import a layer from the filesystem
 
 t = ToSvg(domain=lay.layer.domain, source='taxii')    # Use taxii server to get data for template
-t.to_svg(layer=lay, filepath="example.svg")           # render the layer to an SVG file
+t.to_svg(lay, filepath="example.svg")           # render the layer to an SVG file
 ```
 
 Further documentation for the navlayers module can be found [here](https://github.com/mitre-attack/mitreattack-python/blob/master/mitreattack/navlayers/README.md).
@@ -85,7 +85,7 @@ Two command line tools have been included in this package as part of the `navlay
 This command line tool allows users to convert a [navigator](https://github.com/mitre-attack/attack-navigator)
   layer file to either an svg image or excel file using the functionality provided by the navlayers module. 
  Details about the SVG configuration json mentioned below can be found in the [SVGConfig](https://github.com/mitre-attack/mitreattack-python/blob/master/mitreattack/navlayers/README.md#svgconfig) entry within the navlayers module documentation.
-```
+```commandline
 C:\Users\attack>layerExporter_cli -h
 usage: layerExporter_cli [-h] -m {svg,excel} [-s {taxii,local,remote}]
                             [--resource RESOURCE] -o OUTPUT [OUTPUT ...]
@@ -119,7 +119,7 @@ C:\Users\attack>layerExporter_cli -m svg -s taxii -l settings/config.json -o out
 
 ##### attackToExcel_cli
 This command line tool allows users to generate excel spreadsheets representing the ATT&CK dataset.
-```
+```commandline
 C:\Users\attack>attackToExcel_cli -h
 usage: attackToExcel_cli [-h]
                          [-domain {enterprise-attack,mobile-attack,ics-attack}]
@@ -145,7 +145,7 @@ C:\Users\attack>attackToExcel_cli -domain ics-attack -version v8.1 -output expor
 This command line tool allows users to generate [ATT&CK Navigator](https://github.com/mitre-attack/attack-navigator) 
 layer files from either a specific group, software, or mitigation. Alternatively, users can generate a layer file with a
 mapping to all associated groups, software, or mitigations across the techniques within ATT&CK. 
-```
+```commandline
 C:\Users\attack>layerGenerator_cli -h
 usage: layerGenerator_cli [-h]
                              (--overview-type {group,software,mitigation,datasource} | --mapped-to MAPPED_TO | --batch-type {group,software,mitigation,datasource})
@@ -179,7 +179,7 @@ optional arguments:
   
 C:\Users\attack>layerGenerator_cli --domain enterprise --source taxii --mapped-to S0065 --output generated_layer.json
 C:\Users\attack>layerGenerator_cli --domain mobile --source taxii --overview-type mitigation --output generated_layer2.json
-C:\Users\attack>layerGenerator_cli --domain ics --source taxii --mass-type software
+C:\Users\attack>layerGenerator_cli --domain ics --source taxii --batch-type software
 C:\Users\attack>layerGenerator_cli --domain enterprise --source taxii --overview-type datasource --output generated_layer3.json
 ```
 
@@ -206,8 +206,8 @@ into an [ATT&CK collection index](https://github.com/center-for-threat-informed-
 that summarizes the contents of the linked collections.
 ```commandline
 C:\Users\attack>collectionToIndex_cli -h
-usage: collection_to_index.py [-h] [-output OUTPUT]
-                              (-files collection1 [collection2 ...] | -folders FOLDERS [FOLDERS ...])
+usage: collection_to_index.py [-h] [--output OUTPUT]
+                              (--files collection1 [collection2 ...] | --folders FOLDERS [FOLDERS ...])
                               name description root_url
 
 Create a collection index from a set of collections
@@ -223,20 +223,20 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -output OUTPUT        filename for the output collection index file
-  -files collection1 [collection2 ...]
+  --output OUTPUT        filename for the output collection index file
+  --files collection1 [collection2 ...]
                         list of collections to include in the index
-  -folders FOLDERS [FOLDERS ...]
+  --folders FOLDERS [FOLDERS ...]
                         folder of JSON files to treat as collections
-C:\Users\attack>collectionToIndex_cli test_index "a layer created as a demo" www.example.com -files C:\Users\attack\examples\collection.json -output C:\Users\attack\examples\index.json
+C:\Users\attack>collectionToIndex_cli test_index "a layer created as a demo" www.example.com --files C:\Users\attack\examples\collection.json --output C:\Users\attack\examples\index.json
 ```
 ##### StixToCollection_cli
 This command line tool allows users to transform raw stix bundle files into versions featuring [collection](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/blob/master/docs/collections.md#collections) objects.
 It is compatible with both STIX 2.0 and STIX 2.1 bundles.
 ```commandline
 C:\Users\attack>stixToCollection_cli -h
-usage: stix_to_collection.py [-h] [-input INPUT] [-output OUTPUT]
-                             [-description DESCRIPTION]
+usage: stix_to_collection.py [-h] [--input INPUT] [--output OUTPUT]
+                             [--description DESCRIPTION]
                              name version
 
 Update a STIX 2.0 or 2.1 bundle to include a collection object referencing the
@@ -248,13 +248,13 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -input INPUT          the input bundle file
-  -output OUTPUT        the output bundle file
-  -description DESCRIPTION
+  --input INPUT          the input bundle file
+  --output OUTPUT        the output bundle file
+  --description DESCRIPTION
                         description to use for the generated collection
 
-C:\Users\attack>stixToCollection "2.0 demo bundle" 9.1 -input C:\Users\bundles\enterprise-bundle-2_0.json
-C:\Users\attack>stixToCollection "2.1 demo bundle" 9.1 -input C:\Users\bundles\enterprise-bundle-2_1.json
+C:\Users\attack>stixToCollection "2.0 demo bundle" 9.1 --input C:\Users\bundles\enterprise-bundle-2_0.json
+C:\Users\attack>stixToCollection "2.1 demo bundle" 9.1 --input C:\Users\bundles\enterprise-bundle-2_1.json
 ```
 ## Related MITRE Work
 #### CTI

--- a/mitreattack/attackToExcel/stixToDf.py
+++ b/mitreattack/attackToExcel/stixToDf.py
@@ -19,6 +19,7 @@ MATRIX_PLATFORMS_LOOKUP = {"enterprise-attack": ['PRE', 'Windows', 'macOS', 'Lin
                                           "Control Server", "Input/Output Server", "Windows", "Human-Machine Interface",
                                           "Engineering Workstation", "Data Historian"]}
 
+TITLE_EXCLUSIONS = ['and']
 
 def remove_revoked_deprecated(stix_objects):
     """Remove any revoked or deprecated objects from queries made to the data source"""
@@ -127,7 +128,8 @@ def techniquesToDf(src, domain):
 
         # sub-technique properties
         tactic_shortnames = list(map(lambda kcp: kcp["phase_name"], technique["kill_chain_phases"]))
-        tactics = list(map(lambda t: t.replace("-", " ").title(), tactic_shortnames))
+        tactics = list(map(lambda t: ' '.join([x.title() if x not in TITLE_EXCLUSIONS else x for x in t.split('-')]),
+                           tactic_shortnames))
         row["tactics"] = ", ".join(sorted(tactics))
 
         if "x_mitre_detection" in technique:

--- a/mitreattack/collections/collection_to_index.py
+++ b/mitreattack/collections/collection_to_index.py
@@ -151,14 +151,14 @@ def main():
              "the collection URL"
     )
     parser.add_argument(
-        "-output",
+        "--output",
         type=str,
         default="index.json",
         help="filename for the output collection index file"
     )
     input_options = parser.add_mutually_exclusive_group(required=True)  # require at least one input type
     input_options.add_argument(
-        '-files',
+        '--files',
         type=str,
         nargs="+",
         default=None,
@@ -166,7 +166,7 @@ def main():
         help="list of collections to include in the index"
     )
     input_options.add_argument(
-        '-folders',
+        '--folders',
         type=str,
         nargs="+",
         default=None,

--- a/mitreattack/collections/stix_to_collection.py
+++ b/mitreattack/collections/stix_to_collection.py
@@ -85,17 +85,17 @@ def main():
                         help="the name for the generated collection object")
     parser.add_argument("version",
                         help="the ATT&CK version for the generated collection object")
-    parser.add_argument("-input",
+    parser.add_argument("--input",
                         type=str,
                         default="bundle.json",
                         help="the input bundle file"
                         )
-    parser.add_argument("-output",
+    parser.add_argument("--output",
                         type=str,
                         default="bundle_out.json",
                         help="the output bundle file"
                         )
-    parser.add_argument("-description",
+    parser.add_argument("--description",
                         type=str,
                         default=None,
                         help="description to use for the generated collection")


### PR DESCRIPTION
Addresses #53. 

The solution I went with allows for whitelisting certain words for exclusion in the capitalization process, with the current whitelist consisting of "and". 