### PR TITLE
Fix Layer init when passing name and domain arguments

### DIFF
--- a/mitreattack/navlayers/core/layer.py
+++ b/mitreattack/navlayers/core/layer.py
@@ -15,7 +15,7 @@ class Layer:
         self.__layer = None
         self.strict = strict
         if name and domain:
-            self.__data = dict(name=name, domain=domain)
+            self._data = dict(name=name, domain=domain)
             self._build()
         elif isinstance(init_data, str):
             self.from_str(init_data)


### PR DESCRIPTION
Fix Layer init when passing name and domain arguments.
Fixes #60.