### PR TITLE
Bugs/63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Staged in Develop
+## Fixes
+- Patched core layer code to properly store 8-hex colors
+- Patched core layer code to properly handle non-ascii characters when ingesting text
+- Patched core layer code to properly initialize layers during instantiation
+- Patched core layer code to properly support Metadata, MetaDiv, Link, LinkDiv instantiation
+
 # v1.4.4 - 2/22/2022
 ## Fixes
 - Patched core layer code to support minor changes in the 4.3 layer format

--- a/mitreattack/navlayers/core/layer.py
+++ b/mitreattack/navlayers/core/layer.py
@@ -15,7 +15,7 @@ class Layer:
         self.__layer = None
         self.strict = strict
         if isinstance(name, str) and isinstance(domain, str):
-            self._data = dict(name=name, domain=domain)
+            self.__data = dict(name=name, domain=domain)
             self._build()
         elif isinstance(init_data, str):
             self.from_str(init_data)
@@ -39,7 +39,7 @@ class Layer:
             :param init_str: the string representing the layer data to
                 be loaded
         """
-        self._data = json.loads(init_str)
+        self.__data = json.loads(init_str)
         self._build()
 
     def from_dict(self, init_dict):
@@ -48,8 +48,8 @@ class Layer:
             :param init_dict: the dictionary representing the layer data to
                 be loaded
         """
-        self._data = init_dict
-        if self._data != {}:
+        self.__data = init_dict
+        if self.__data != {}:
             self._build()
 
     def from_file(self, filename):
@@ -59,7 +59,7 @@ class Layer:
         """
         with open(filename, 'r') as fio:
             raw = fio.read()
-            self._data = json.loads(raw)
+            self.__data = json.loads(raw)
             self._build()
 
     def to_file(self, filename):
@@ -79,7 +79,7 @@ class Layer:
             Loads the data stored in self.data into a LayerObj (self.layer)
         """
         try:
-            self.__layer = _LayerObj(self._data['name'],  self._data['domain'])
+            self.__layer = _LayerObj(self.__data['name'],  self.__data['domain'])
         except BadType or BadInput as e:
             handler(type(self).__name__, 'Layer is malformed: {}. '
                                          'Unable to load.'.format(e))
@@ -91,10 +91,10 @@ class Layer:
             self.__layer = None
             return
 
-        for key in self._data:
+        for key in self.__data:
             if key not in ['name', 'domain']:
                 try:
-                    self.__layer._linker(key, self._data[key])
+                    self.__layer._linker(key, self.__data[key])
                 except Exception as e:
                     if self.strict:
                         handler(type(self).__name__, "{} encountered [{}]. "

--- a/mitreattack/navlayers/core/layerobj.py
+++ b/mitreattack/navlayers/core/layerobj.py
@@ -306,6 +306,12 @@ class _LayerObj:
                 if isinstance(entry, Metadata) or isinstance(entry, MetaDiv):
                     loadChecker(type(self).__name__, entry.get_dict(), ['name', 'value'], "metadata")
                     self.__metadata.append(entry)
+                elif isinstance(entry, dict):
+                    loadChecker(type(self).__name__, entry, ['name', 'value'], "metadata")
+                    if entry['name'] == "DIVIDER":
+                        self.__metadata.append(MetaDiv(active=entry['value']))
+                    else:
+                        self.__metadata.append(Metadata(name=entry['name'], value=entry['value']))
                 else:
                     pass  # Object in the list was not of Metadata or MetaDiv type
             except MissingParameters as e:
@@ -327,10 +333,21 @@ class _LayerObj:
         entry = ""
         try:
             for entry in links:
-                if "divider" in entry:
-                    self.__links.append(Link(entry["divider"]))
+                if isinstance(entry, Link):
+                    loadChecker(type(self).__name__, entry.get_dict(), ['label', 'url'], "link")
+                    self.__links.append(entry)
+                elif isinstance(entry, LinkDiv):
+                    loadChecker(type(self).__name__, entry.get_dict(), ['name', 'value'], "linkdiv")
+                    self.__links.append(entry)
+                elif isinstance(entry, dict):
+                    if 'name' in entry and entry['name'] == "DIVIDER":
+                        loadChecker(type(self).__name__, entry, ['name', 'value'], "linkdiv")
+                        self.__links.append(LinkDiv(active=entry['value']))
+                    else:
+                        loadChecker(type(self).__name__, entry, ['label', 'url'], "link")
+                        self.__links.append(Link(label=entry['label'], url=entry['url']))
                 else:
-                    self.__links.append(Link(entry['label'], entry['url']))
+                    pass
         except KeyError as e:
             handler(type(self).__name__, 'Link {} is missing parameters: '
                                          '{}. Unable to load.'

--- a/mitreattack/navlayers/core/technique.py
+++ b/mitreattack/navlayers/core/technique.py
@@ -107,6 +107,12 @@ class Technique:
                     if isinstance(entry, Metadata) or isinstance(entry, MetaDiv):
                         loadChecker(type(self).__name__, entry.get_dict(), ['name', 'value'], "metadata")
                         self.__metadata.append(entry)
+                    elif isinstance(entry, dict):
+                        loadChecker(type(self).__name__, entry, ['name', 'value'], "metadata")
+                        if entry['name'] == "DIVIDER":
+                            self.__metadata.append(MetaDiv(active=entry['value']))
+                        else:
+                            self.__metadata.append(Metadata(name=entry['name'], value=entry['value']))
                     else:
                         pass  # Object in the list was not of Metadata or MetaDiv classes
                 except MissingParameters as e:
@@ -153,10 +159,21 @@ class Technique:
         entry = ""
         try:
             for entry in links:
-                if "divider" in entry:
-                    self.__links.append(Link(entry["divider"]))
+                if isinstance(entry, Link):
+                    loadChecker(type(self).__name__, entry.get_dict(), ['label', 'url'], "link")
+                    self.__links.append(entry)
+                elif isinstance(entry, LinkDiv):
+                    loadChecker(type(self).__name__, entry.get_dict(), ['name', 'value'], "linkdiv")
+                    self.__links.append(entry)
+                elif isinstance(entry, dict):
+                    if 'name' in entry and entry['name'] == "DIVIDER":
+                        loadChecker(type(self).__name__, entry, ['name', 'value'], "linkdiv")
+                        self.__links.append(LinkDiv(active=entry['value']))
+                    else:
+                        loadChecker(type(self).__name__, entry, ['label', 'url'], "link")
+                        self.__links.append(Link(label=entry['label'], url=entry['url']))
                 else:
-                    self.__links.append(Link(entry['label'], entry['url']))
+                    pass
         except KeyError as e:
             handler(type(self).__name__, 'Link {} is missing parameters: '
                                          '{}. Unable to load.'

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,5 +1,5 @@
 from resources import testing_data
-from mitreattack.navlayers import Layer, ToExcel, ToSvg, LayerOps
+from mitreattack.navlayers import Layer, ToExcel, ToSvg, LayerOps, Technique, MetaDiv, Metadata, Link, LinkDiv
 import os
 import shutil
 
@@ -115,3 +115,22 @@ class TestLayers:
         layers_dict = get_layers_by_name([testing_data.example_layer_v3_longer, testing_data.example_layer_v3_all])
         out_layer = build_combined_layer(layers_dict)
         assert isinstance(out_layer, Layer)
+
+    @staticmethod
+    def test_direct_meta():
+        Layer(init_data={'name': "Layer A", 'domain': "enterprise-attack"})
+        layer_technique = Technique(tID="T1003")
+        layer_technique.metadata = [Metadata(name="Metadata", value="1"), MetaDiv(active=True)]
+        layer_technique2 = Technique(tID="T1004")
+        layer_technique2.metadata = [dict(name="Metadata", value="1"), dict(name="DIVIDER", value=True)]
+        assert layer_technique.metadata[0].get_dict() == layer_technique2.metadata[0].get_dict()
+        assert layer_technique.metadata[1].get_dict() == layer_technique2.metadata[1].get_dict()
+
+    @staticmethod
+    def test_direct_link():
+        layer_technique = Technique(tID="T1003")
+        layer_technique.links = [Link(label='test', url='127.0.0.1'), LinkDiv(active=True)]
+        layer_technique2 = Technique(tID="T1004")
+        layer_technique2.links = [dict(label='test', url='127.0.0.1'), dict(name='DIVIDER', value=True)]
+        assert layer_technique.links[0].get_dict() == layer_technique2.links[0].get_dict()
+        assert layer_technique.links[1].get_dict() == layer_technique2.links[1].get_dict()


### PR DESCRIPTION
Expands on https://github.com/mitre-attack/mitreattack-python/pull/65 to provide backwards compatibility for dictionary creation of Metadata, MetaDiv, Link and LinkDiv objects.