### PR TITLE
Fixed `tid` set logic in MatrixGen

### DIFF
--- a/mitreattack/attackToExcel/stixToDf.py
+++ b/mitreattack/attackToExcel/stixToDf.py
@@ -9,6 +9,9 @@ from loguru import logger
 from stix2 import Filter, MemoryStore
 from tqdm import tqdm
 
+from mitreattack.constants import MITRE_ATTACK_ID_SOURCE_NAMES
+
+
 # Lookup module for Platforms - each matrix has a list of possible platforms, and each platform with multiple
 #   subplatforms has a corresponding entry. This allows for a pseudo-recursive lookup of subplatforms, as the presence
 #   of a platform at the top level of this lookup indicates the existence of subplatforms.
@@ -106,11 +109,7 @@ def parseBaseStix(sdo):
     row = {}
     url = None
     if sdo.get("external_references"):
-        if sdo["external_references"][0]["source_name"] in [
-            "mitre-attack",
-            "mitre-mobile-attack",
-            "mitre-ics-attack",
-        ]:
+        if sdo["external_references"][0]["source_name"] in MITRE_ATTACK_ID_SOURCE_NAMES:
             row["ID"] = sdo["external_references"][0]["external_id"]
             url = sdo["external_references"][0]["url"]
     if "name" in sdo:
@@ -812,11 +811,7 @@ def relationshipsToDf(src, relatedType=None):
             """Add data for one side of the mapping."""
             # logger.debug(sdo)
             if sdo.get("external_references"):
-                if sdo["external_references"][0]["source_name"] in [
-                    "mitre-attack",
-                    "mitre-mobile-attack",
-                    "mitre-ics-attack",
-                ]:
+                if sdo["external_references"][0]["source_name"] in MITRE_ATTACK_ID_SOURCE_NAMES:
                     row[f"{label} ID"] = sdo["external_references"][0]["external_id"]  # "source ID" or "target ID"
             if "name" in sdo:
                 row[f"{label} name"] = sdo["name"]  # "source name" or "target name"

--- a/mitreattack/constants.py
+++ b/mitreattack/constants.py
@@ -1,0 +1,3 @@
+# The ATT&CK ID entry always has a source_name with a value from:
+# ['mitre-attack', 'mitre-mobile-attack', 'mobile-attack', 'mitre-ics-attack']
+MITRE_ATTACK_ID_SOURCE_NAMES = ['mitre-attack', 'mobile-attack', 'mitre-mobile-attack', 'mitre-ics-attack']

--- a/mitreattack/navlayers/exporters/matrix_gen.py
+++ b/mitreattack/navlayers/exporters/matrix_gen.py
@@ -197,7 +197,7 @@ class MatrixGen:
         for entry in techs:
             if entry['kill_chain_phases'][0]['kill_chain_name'] == 'mitre-attack' or \
                             entry['kill_chain_phases'][0]['kill_chain_name'] == 'mitre-mobile-attack':
-                tid = [t['external_id'] for t in entry['external_references'] if 'attack' in t['source_name']]
+                tid = [t['external_id'] for t in entry['external_references'][:1] if 'attack' in t['source_name']]
                 platform_tags = []
                 if 'x_mitre_platforms' in entry:
                     platform_tags = entry['x_mitre_platforms']

--- a/mitreattack/navlayers/exporters/matrix_gen.py
+++ b/mitreattack/navlayers/exporters/matrix_gen.py
@@ -3,6 +3,7 @@ from stix2.datastore.memory import _add
 from taxii2client.v20 import Server, Collection
 import requests
 import json
+from mitreattack.constants import MITRE_ATTACK_ID_SOURCE_NAMES
 
 
 class DomainNotLoadedError(Exception):
@@ -195,8 +196,7 @@ class MatrixGen:
         techs = self._search(domain, [Filter('type', '=', 'attack-pattern'),
                                       Filter('kill_chain_phases.phase_name', '=', tactic)])
         for entry in techs:
-            if entry['kill_chain_phases'][0]['kill_chain_name'] == 'mitre-attack' or \
-                            entry['kill_chain_phases'][0]['kill_chain_name'] == 'mitre-mobile-attack':
+            if entry['kill_chain_phases'][0]['kill_chain_name'] in MITRE_ATTACK_ID_SOURCE_NAMES:
                 tid = [t['external_id'] for t in entry['external_references'][:1] if 'attack' in t['source_name']]
                 platform_tags = []
                 if 'x_mitre_platforms' in entry:
@@ -277,7 +277,7 @@ class MatrixGen:
             if cycle:
                 for entry in to_add:
                     sr = entry[0]
-                    joins.append([entry[0], column-1, len(stechs[entry[1]])])
+                    joins.append([entry[0], column - 1, len(stechs[entry[1]])])
                     for element in stechs[entry[1]]:
                         matrix_obj[(sr, column)] = element.name
                         sr += 1

--- a/mitreattack/navlayers/generators/gen_helpers.py
+++ b/mitreattack/navlayers/generators/gen_helpers.py
@@ -1,4 +1,3 @@
-# MITRE_ATTACK_DOMAIN_STRINGS = ['mitre-attack', 'mitre-mobile-attack', 'mitre-ics-attack']  # TODO delete line
 from mitreattack.constants import MITRE_ATTACK_ID_SOURCE_NAMES
 
 

--- a/mitreattack/navlayers/generators/gen_helpers.py
+++ b/mitreattack/navlayers/generators/gen_helpers.py
@@ -1,4 +1,5 @@
-MITRE_ATTACK_DOMAIN_STRINGS = ['mitre-attack', 'mitre-mobile-attack', 'mitre-ics-attack']
+# MITRE_ATTACK_DOMAIN_STRINGS = ['mitre-attack', 'mitre-mobile-attack', 'mitre-ics-attack']  # TODO delete line
+from mitreattack.constants import MITRE_ATTACK_ID_SOURCE_NAMES
 
 
 def remove_revoked_depreciated(listing):
@@ -36,7 +37,7 @@ def get_attack_id(obj):
     """
     if not obj['type'].startswith('x-mitre'):
         for entry in obj['external_references']:
-            if entry['source_name'] in MITRE_ATTACK_DOMAIN_STRINGS:
+            if entry['source_name'] in MITRE_ATTACK_ID_SOURCE_NAMES:
                 return entry['external_id']
     else:
         return obj['id']


### PR DESCRIPTION
In enterprise-attack v11.2, there are two `attack-pattern` STIX objects which trigger the unhandled exceptions described in Issue #76. They are as follows:
```
[
    "attack-pattern--970a3432-3237-47ad-bcca-7d8cbb217736",
    "attack-pattern--824add00-99a1-4b15-9a2d-6c5683b7b497"
]
```

Of note, the exceptions are not specific to the TAXII server. Setting the `source` parameter in `_get_technique_listing` to `local` instead of `source=taxii` and loading STIX direct from the [latest source](https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json) still yields the same exceptions.

The first attack-pattern contains the following two edge cases. These are elements in the object's `external_references` array where `"[aA]ttack"` is a substring in their respective `source_name` properties.
```
{
		"source_name": "Github PSAttack", <--- HERE
		"description": "Haight, J. (2016, April 21). PS>Attack. Retrieved June 1, 2016.",
		"url": "https://github.com/jaredhaight/PSAttack"
}, 
{
		"source_name": "inv_ps_attacks", <--- HERE
		"description": "Hastings, M. (2014, July 16). Investigating PowerShell Attacks. Retrieved December 1, 2021.",
		"url": "https://powershellmagazine.com/2014/07/16/investigating-powershell-attacks/"
}
```

The second attack-pattern contains these two edge cases:
```
{
		"source_name": "inv_ps_attacks", <--- HERE
		"description": "Hastings, M. (2014, July 16). Investigating PowerShell Attacks. Retrieved December 1, 2021.",
		"url": "https://powershellmagazine.com/2014/07/16/investigating-powershell-attacks/"
}, 
{
		"source_name": "Praetorian TLS Downgrade Attack 2014", <--- HERE
		"description": "Praetorian. (2014, August 19). Man-in-the-Middle TLS Protocol Downgrade Attack. Retrieved October 8, 2021.",
		"url": "https://www.praetorian.com/blog/man-in-the-middle-tls-ssl-protocol-downgrade-attack/"
}
```
Common amongst all 4 edge cases is their non-zero index position in `external_references`.

Under certain conditions, `MatrixGen._get_technique_listing` attempts to read every element's `external_id` property when the string "_attack_" is detected in the element's `source_name` property. The problem is - this logic should only apply to the _first_ element in the `external_references` array. Currently, it is applying to _all_ elements.

Moreover, I found a tangentially related issue: the read operation for `tid` is only triggering if the parent objects' `kill_chain_phases[0]['kill_chain_name']` element is equal to string `"mitre-mobile"` or `"mitre-mobile-attack"`. `"mobile-attack"`, and `"mitre-ics-attack"` are also valid values for this element, so the reference activation list needs to expand from 2 to 4.

To summarize, there are two issues with detecting ATT&CK ID entries in `external_references`. 

Currently, the logic is:

- If it exists, the ATT&CK ID is stored anywhere in `external_references` (_ISSUE 1_)
- The ATT&CK ID entry always has a `source_name` with a value from: ['mitre-attack', 'mitre-mobile-attack'] (_ISSUE 2_)
- The ATT&CK ID entry always has the three properties: `source_name`, `external_id`, and `url`

But the logic should be:

- If it exists, the ATT&CK ID is stored  in `external_references[0]`
- The ATT&CK ID entry always has a `source_name` with a value from: ['mitre-attack', 'mitre-mobile-attack', 'mobile-attack', 'mitre-ics-attack']
- The ATT&CK ID entry always has the three properties: `source_name`, `external_id`, and `url`