### PR TITLE
Add support for campaigns to the diffStix changelog script

### DIFF
--- a/mitreattack/diffStix/changelog_helper.py
+++ b/mitreattack/diffStix/changelog_helper.py
@@ -896,12 +896,11 @@ class DiffStix(object):
                 )
                 domains += f"### {domainToDomainLabel[domain]}\n\n"  # e.g "Enterprise"
                 # Skip mobile and ics sections for data sources
-                if domain in ["mobile-attack", "ics-attack"] and obj_type == "datasource":
-                    domainName = 'Mobile' if domain == 'mobile-attack' else 'ICS'
+                if domain == "mobile-attack" and obj_type == "datasource":
                     logger.debug(
-                        f"Skipping - ATT&CK for {domainName} does not support data sources"
+                        f"Skipping - ATT&CK for Mobile does not support data sources"
                     )
-                    domains += f"ATT&CK for {domainName} does not support data sources\n\n"
+                    domains += f"ATT&CK for Mobile does not support data sources\n\n"
                     continue
                 domain_sections = ""
                 for section, values in self.data[obj_type][domain].items():

--- a/mitreattack/diffStix/changelog_helper.py
+++ b/mitreattack/diffStix/changelog_helper.py
@@ -838,11 +838,11 @@ class DiffStix(object):
             def version(item, section):
                 if section in ['additions', 'deprecations', 'revocations']:
                     # only display current version
-                    color = "#929393" if self.version_increment_is_valid(None, item['x_mitre_version'], section) else "#e32a4c"
+                    color = "#929393" if self.version_increment_is_valid(None, item['x_mitre_version'], section) else "#eb6635"
                     return f"<small style=\"color:{color}\">(v{item['x_mitre_version']})</small>"
                 else:
                     # display previous and current version
-                    color = "#929393" if self.version_increment_is_valid(item['previous_version'], item['x_mitre_version'], section) else "#e32a4c"
+                    color = "#929393" if self.version_increment_is_valid(item['previous_version'], item['x_mitre_version'], section) else "#eb6635"
                     return f"<small style=\"color:{color}\">(v{item['previous_version']}&#8594;v{item['x_mitre_version']})</small>"
 
             groupings = self.get_groupings(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ pandas>=1.1.5
 pyinstrument>=4.3.0
 pytest>=7.1.2
 pytest-cov>=3.0.0
+python-dateutil
 Pillow>=7.1.2
 requests>=2.21.0
 stix2>=3.0.1

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setuptools.setup(
         'numpy',
         'openpyxl',
         'pandas',
+        'python-dateutil',
         'Pillow',
         'requests',
         'stix2',


### PR DESCRIPTION
Summary of changes:
- Added support for campaigns to the diffStix changelog script
- Added validation to object versioning during changelog generation. The script logs a warning if an object version has an invalid increment (i.e. `v1.1->v1.4`, `v1.0->v2.4`, etc.)
- Added object versions to the changelog. Version text is styled orange if the version increment is invalid.