### PR TITLE
89 svg export bug

### DIFF
--- a/mitreattack/navlayers/exporters/svg_templates.py
+++ b/mitreattack/navlayers/exporters/svg_templates.py
@@ -67,7 +67,7 @@ class SvgTemplates:
         ff = config.font
         d = draw.Drawing(max_x, max_y, origin=(0, -max_y), displayInline=False)
         psych = 0
-        overlay = None
+    
         if config.showHeader:
             border = convertToPx(config.border, config.unit)
             root = G(tx=border, ty=border, style=f"font-family: {ff}")
@@ -170,63 +170,65 @@ class SvgTemplates:
                     header.append(bA)
                     bA.append(gA)
                     psych += 1
-                if config.showLegend:
-                    # get all gradient colors
-                    gradient_colors = []
-                    if gradient is not False:
-                        gr = gradient
-                        if gr is None:
-                            gr = Gradient(colors=["#ff6666", "#ffe766", "#8ec843"], minValue=1, maxValue=100)
-                        div = round((gr.maxValue - gr.minValue) / (len(gr.colors) * 2 - 1))
-                        for i in range(0, len(gr.colors) * 2 - 1):
-                            gradient_colors.append((gr.compute_color(int(gr.minValue + div * i)), gr.minValue + div * i))
-                        gradient_colors.append((gr.compute_color(gr.maxValue), gr.maxValue))
-                    
-                    # get all legend colors
-                    legend_colors = []
-                    if legend:
-                        for l in legend:
-                            legend_colors.append((l.color, l.label))
 
-                    # build gradient/legend
-                    if config.legendDocked:
-                        b3 = G(tx=operation_x / header_count * psych + 1.5 * border * psych)
-                        g3 = SVG_HeaderBlock().build(
-                            height=header_height,
-                            width=header_width,
-                            label="legend",
-                            variant="graphic",
-                            gradient_colors=gradient_colors,
-                            legend_colors=legend_colors,
-                            config=config,
-                        )
-                        header.append(b3)
-                        b3.append(g3)
-                        psych += 1
-                    else:
-                        adjusted_height = convertToPx(config.legendHeight, config.unit)
-                        adjusted_width = convertToPx(config.legendWidth, config.unit)
-                        g3 = SVG_HeaderBlock().build(
-                            height=adjusted_height,
-                            width=adjusted_width,
-                            label="legend",
-                            variant="graphic",
-                            gradient_colors=gradient_colors,
-                            legend_colors=legend_colors,
-                            config=config,
-                        )
-                        lx = convertToPx(config.legendX, config.unit)
-                        if not lx:
-                            lx = max_x - adjusted_width - convertToPx(config.border, config.unit)
-                        ly = convertToPx(config.legendY, config.unit)
-                        if not ly:
-                            ly = max_y - adjusted_height - convertToPx(config.border, config.unit)
-                        overlay = G(tx=lx, ty=ly)
-                        if (ly + adjusted_height) > max_y or (lx + adjusted_width) > max_x:
-                            print("[WARNING] - Floating legend will render partly out of view...")
-                        overlay.append(g3)
+                # build gradient/legend
+                if config.showLegend and config.legendDocked:
+                    b3 = G(tx=operation_x / header_count * psych + 1.5 * border * psych)
+                    g3 = self._build_legend(gradient, legend, header_height, header_width, config)
+                    header.append(b3)
+                    b3.append(g3)
+                    psych += 1
             d.append(root)
+
+        # undocked legend
+        overlay = None
+        if config.showLegend and not config.legendDocked:
+            adjusted_height = convertToPx(config.legendHeight, config.unit)
+            adjusted_width = convertToPx(config.legendWidth, config.unit)
+
+            g3 = self._build_legend(gradient, legend, adjusted_height, adjusted_width, config)
+
+            lx = convertToPx(config.legendX, config.unit)
+            if not lx:
+                lx = max_x - adjusted_width - convertToPx(config.border, config.unit)
+            ly = convertToPx(config.legendY, config.unit)
+            if not ly:
+                ly = max_y - adjusted_height - convertToPx(config.border, config.unit)
+            overlay = G(tx=lx, ty=ly)
+            if (ly + adjusted_height) > max_y or (lx + adjusted_width) > max_x:
+                print("[WARNING] - Floating legend will render partly out of view...")
+            overlay.append(g3)
+
         return d, psych, overlay
+
+    def _build_legend(self, gradient, legend, header_height, header_width, config):
+        # get all gradient colors
+        gradient_colors = []
+        if gradient is not False:
+            gr = gradient
+            if gr is None:
+                gr = Gradient(colors=["#ff6666", "#ffe766", "#8ec843"], minValue=1, maxValue=100)
+            div = round((gr.maxValue - gr.minValue) / (len(gr.colors) * 2 - 1))
+            for i in range(0, len(gr.colors) * 2 - 1):
+                gradient_colors.append((gr.compute_color(int(gr.minValue + div * i)), gr.minValue + div * i))
+            gradient_colors.append((gr.compute_color(gr.maxValue), gr.maxValue))
+        
+        # get all legend colors
+        legend_colors = []
+        if legend:
+            for l in legend:
+                legend_colors.append((l.color, l.label))
+
+        legend_block = SVG_HeaderBlock().build(
+            height=header_height,
+            width=header_width,
+            label="legend",
+            variant="graphic",
+            gradient_colors=gradient_colors,
+            legend_colors=legend_colors,
+            config=config,
+        )
+        return legend_block
 
     def get_tactic(self, tactic, height, width, config, colors=[], scores=[], subtechs=[], exclude=[], mode=(True, False)):
         """Build a 'tactic column' svg object.
@@ -394,7 +396,7 @@ class SvgTemplates:
         technique_height = convertToPx(config.height, config.unit) - header_offset - border
         technique_height /= (max(lengths) + 1)
 
-        # create SVG
+        # create SVG object
         svg_glob = G(tx=border)
 
         # build SVG

--- a/mitreattack/navlayers/exporters/svg_templates.py
+++ b/mitreattack/navlayers/exporters/svg_templates.py
@@ -201,7 +201,16 @@ class SvgTemplates:
 
         return d, psych, overlay
 
-    def _build_legend(self, gradient, legend, header_height, header_width, config):
+    def _build_legend(self, gradient, legend, height, width, config):
+        """Build the legend block for the SVG
+
+        :param gradient: Gradient information included with the layer
+        :param legend: List of legend items
+        :param height: Height of the legend block
+        :param width: Width of the legend block
+        :param config: SVGConfig object
+        :return: The SVG legend block
+        """
         # get all gradient colors
         gradient_colors = []
         if gradient is not False:
@@ -220,8 +229,8 @@ class SvgTemplates:
                 legend_colors.append((l.color, l.label))
 
         legend_block = SVG_HeaderBlock().build(
-            height=header_height,
-            width=header_width,
+            height=height,
+            width=width,
             label="legend",
             variant="graphic",
             gradient_colors=gradient_colors,

--- a/mitreattack/navlayers/exporters/to_svg.py
+++ b/mitreattack/navlayers/exporters/to_svg.py
@@ -82,7 +82,7 @@ class SVGConfig:
 
         :param filename: The file to read from
         """
-        with open(filename, "r") as fio:
+        with open(filename, "r", encoding="utf-16") as fio:
             raw = fio.read()
 
         self._data = json.loads(raw)

--- a/mitreattack/navlayers/exporters/to_svg.py
+++ b/mitreattack/navlayers/exporters/to_svg.py
@@ -16,45 +16,26 @@ class NoLayer(Exception):
 class SVGConfig:
     """A SVGConfig object."""
 
-    d_width = 8.5
-    d_height = 11
-    d_headerHeight = 1
-    d_unit = "in"
-    d_showSubtechniques = "expanded"
-    d_font = "sans-serif"
-    d_tableBorderColor = "#6B7279"
-    d_showHeader = True
-    d_legendDocked = True
-    d_legendX = 0
-    d_legendY = 0
-    d_legendWidth = 2
-    d_legendHeight = 1
-    d_showLegend = True
-    d_showFilters = True
-    d_showAbout = True
-    d_showDomain = True
-    d_border = 0.104
-
     def __init__(
         self,
-        width=d_width,
-        height=d_height,
-        headerHeight=d_headerHeight,
-        unit=d_unit,
-        showSubtechniques=d_showSubtechniques,
-        font=d_font,
-        tableBorderColor=d_tableBorderColor,
-        showHeader=d_showHeader,
-        legendDocked=d_legendDocked,
-        legendX=d_legendX,
-        legendY=d_legendY,
-        legendWidth=d_legendWidth,
-        legendHeight=d_legendHeight,
-        showLegend=d_showLegend,
-        showFilters=d_showFilters,
-        showAbout=d_showAbout,
-        showDomain=d_showDomain,
-        border=d_border,
+        width=8.5,
+        height=11,
+        headerHeight=1,
+        unit="in",
+        showSubtechniques="expanded",
+        font="sans-serif",
+        tableBorderColor="#6B7279",
+        showHeader=True,
+        legendDocked=True,
+        legendX=0,
+        legendY=0,
+        legendWidth=2,
+        legendHeight=1,
+        showLegend=True,
+        showFilters=True,
+        showAbout=True,
+        showDomain=True,
+        border=0.104,
     ):
         """Define parameters to configure SVG export.
 
@@ -77,26 +58,6 @@ class SVGConfig:
         :param showDomain: Whether or not to show the Domain Version Header Block
         :param border: What default border width to use
         """
-        # force defaults in case bad values are provided so we don't crash later
-        self.width = self.d_width
-        self.height = self.d_height
-        self.headerHeight = self.d_headerHeight
-        self.unit = self.d_unit
-        self.showSubtechniques = self.d_showSubtechniques
-        self.font = self.d_font
-        self.tableBorderColor = self.d_tableBorderColor
-        self.showHeader = self.d_showHeader
-        self.legendDocked = self.d_legendDocked
-        self.legendX = self.d_legendX
-        self.legendY = self.d_legendY
-        self.legendWidth = self.d_legendWidth
-        self.legendHeight = self.d_legendHeight
-        self.showDomain = self.d_showDomain
-        self.showLegend = self.d_showLegend
-        self.showFilters = self.d_showFilters
-        self.showAbout = self.d_showAbout
-        self.border = self.d_border
-
         self.width = width
         self.height = height
         self.headerHeight = headerHeight
@@ -123,6 +84,7 @@ class SVGConfig:
         """
         with open(filename, "r") as fio:
             raw = fio.read()
+
         self._data = json.loads(raw)
         for entry in self._data:
             patched = entry
@@ -133,7 +95,7 @@ class SVGConfig:
             else:
                 print(f"WARNING - Unidentified Config Field in {filename}: {entry}")
 
-        self.__str__()
+        print(self)
 
     def save_to_file(self, filename=""):
         """Store config to json file.
@@ -164,24 +126,26 @@ class SVGConfig:
 
     def __str__(self):
         """Display current configuration."""
-        print("SVGConfig current settings: ")
-        print(f"width - {self.width}")
-        print(f"height - {self.height}")
-        print(f"headerHeight - {self.headerHeight}")
-        print(f"unit - {self.unit}")
-        print(f"showSubtechniques - {self.showSubtechniques}")
-        print(f"font - {self.font}")
-        print(f"tableBorderColor - {self.tableBorderColor}")
-        print(f"showHeader - {self.showHeader}")
-        print(f"legendDocked - {self.legendDocked}")
-        print(f"legendX - {self.legendX}")
-        print(f"legendY - {self.legendY}")
-        print(f"legendWidth - {self.legendWidth}")
-        print(f"legendHeight - {self.legendHeight}")
-        print(f"showLegend - {self.showLegend}")
-        print(f"showFilters - {self.showFilters}")
-        print(f"showAbout - {self.showAbout}")
-        print(f"border - {self.border}")
+        return (
+            f"SVGConfig settings:\n"
+            f"- width: {self.width}\n"
+            f"- height: {self.height}\n"
+            f"- headerHeight: {self.headerHeight}\n"
+            f"- unit: {self.unit}\n"
+            f"- showSubtechniques: {self.showSubtechniques}\n"
+            f"- font: {self.font}\n"
+            f"- tableBorderColor: {self.tableBorderColor}\n"
+            f"- showHeader: {self.showHeader}\n"
+            f"- legendDocked: {self.legendDocked}\n"
+            f"- legendX: {self.legendX}\n"
+            f"- legendY: {self.legendY}\n"
+            f"- legendWidth: {self.legendWidth}\n"
+            f"- legendHeight: {self.legendHeight}\n"
+            f"- showLegend: {self.showLegend}\n"
+            f"- showFilters: {self.showFilters}\n"
+            f"- showAbout: {self.showAbout}\n"
+            f"- border: {self.border}"
+        )
 
     @property
     def width(self):

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -61,7 +61,7 @@ class TestLayers:
         lay = Layer(testing_data.example_layer_v3_all)
         exp = ToSvg(domain=lay.layer.domain)
         exp.config.load_from_file("resources/demo.json")
-        exp.config.__str__()
+        print(exp.config)
         exp.to_svg(lay)
         os.remove("example.svg")
 


### PR DESCRIPTION
Summary of changes:
- Fixes an issue in the navlayers module where the legend is not generated in the SVG export when `SVGConfig.legendDocked=false` (closes #89).
- Fixes an issue with loading `SVGConfig` settings from file.
- Fixes the `SVGConfig` `__str__()` method to return a string representation of the object.