### PR TITLE
Make pytest pass tests when run in project directory root

### DIFF
--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from resources.testing_data import collection, index
 
@@ -21,10 +22,14 @@ def test_collection_to_index():
 
 def test_stix_to_collection():
     """Test converting stix bundle file to a collection"""
-    with open("resources/ics-bundle.json", "r") as fio:
+    dir = os.path.dirname(__file__)
+    ics_bundle_collection = os.path.join(dir, "resources", "ics-bundle.json")
+    enterprise_bundle_collection = os.path.join(dir, "resources", "enterprise-bundle.json")
+    
+    with open(ics_bundle_collection, "r") as fio:
         v20 = json.load(fio)
 
-    with open("resources/enterprise-bundle.json", "r") as fio:
+    with open(enterprise_bundle_collection, "r") as fio:
         v21 = json.load(fio)
 
     STIXToCollection.stix_to_collection(v20, name="v20_test", version="9.0", description="testing")

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -37,7 +38,8 @@ def test_depreciated_tactics_export(tmp_path: Path, memstore_enterprise_latest: 
 def test_colormap_export(tmp_path: Path, memstore_enterprise_latest: MemoryStore):
     """Test exporting a layer with a gradiant of scores"""
     lay = Layer()
-    lay.from_file("resources/heatmap_example.json")
+    dir = os.path.dirname(__file__)
+    lay.from_file(os.path.join(dir, "resources", "heatmap_example.json"))
     xlsx_output = tmp_path / "layer.xlsx"
     svg_output = tmp_path / "layer.svg"
 


### PR DESCRIPTION
Pytest shows 2 failing tests when it is run from the project root (test_stix_to_collection and test_colormap_export). When the command is run from within the `tests/` folder, the 2 tests pass. Some tests use hardcoded directories and this commit resolves that.

In `tests/`:
![image](https://github.com/mitre-attack/mitreattack-python/assets/135168211/295a16d8-5db3-4ac2-982d-81e05108d48f)

In project root:
![image](https://github.com/mitre-attack/mitreattack-python/assets/135168211/6716dcbc-0e43-463a-bdc6-09b100ca3804)
