### PR TITLE
Fixed orientation of svg subtechnique bars

### DIFF
--- a/mitreattack/navlayers/exporters/svg_objects.py
+++ b/mitreattack/navlayers/exporters/svg_objects.py
@@ -440,6 +440,7 @@ class SVG_Technique:
             gp.append(subtech)
             gp.append(subtext)
             new_offset = new_offset + height
+        y_offset = height * (count + 2)
         if count > 0:
             g.append(
                 drawsvg.Lines(
@@ -456,6 +457,7 @@ class SVG_Technique:
                     close=True,
                     fill=tBC,
                     stroke=tBC,
+                    transform=f'translate(0,{y_offset})'
                 )
             )
         return g, offset + new_offset


### PR DESCRIPTION
Fixed the orientation of the grey subtechnique bars so they align with the edges of their respective subtechniques.

Closes [#166](https://github.com/mitre-attack/mitreattack-python/issues/166)