### PR TITLE
Update/reduce type checker noise

### DIFF
--- a/mitreattack/navlayers/core/exceptions.py
+++ b/mitreattack/navlayers/core/exceptions.py
@@ -55,13 +55,18 @@ def typeChecker(caller, testee, desired_type, field):
     :param caller: the entity that called this function (used for error
         messages)
     :param testee: the element to test
-    :param desired_type: the type the element should be
+    :param desired_type: the type the element should be or a list of
+        allowed types
     :param field: what the element is to be used as (used for error
         messages)
     :raises BadType: error denoting the testee element is not of the
         correct type
     """
-    if not isinstance(testee, desired_type):
+    if isinstance(desired_type, list):
+        if not any(isinstance(testee, t) for t in desired_type):
+            handler(caller, f"{testee} [{field}] is not one of {str(desired_type)}")
+            raise BadType
+    elif not isinstance(testee, desired_type):
         handler(caller, f"{testee} [{field}] is not a {str(desired_type)}")
         raise BadType
 

--- a/mitreattack/navlayers/core/technique.py
+++ b/mitreattack/navlayers/core/technique.py
@@ -94,12 +94,8 @@ class Technique:
     @score.setter
     def score(self, score):
         """Setter for score."""
-        try:
-            typeChecker(type(self).__name__, score, int, "score")
-            self.__score = score
-        except BadType:
-            typeChecker(type(self).__name__, score, float, "score")
-            self.__score = int(score)
+        typeChecker(type(self).__name__, score, [int, float], "score")
+        self.__score = score
 
     @property
     def color(self):


### PR DESCRIPTION
## Reason For Changes
When using the ToExcel exporter I noticed error messages coming from the `typeChecker()` function when I used the `average` score aggregation function. This is because the Techniques' scores come out as a float type. int is checked first, an error message is emitted, then float is checked.

## Summary of Changes
I updated `typeChecker()` function to support a list of types, and I updated the `score()` method in technique.py to utilize the change.

## Testing
I re-ran my code to export a layer to excel. The code worked as expected and I no longer received the error messages. I also ran the unit tests locally an everything continued to pass