### PR TITLE
perf: optimize Excel export by eliminating redundant STIX processing

### DIFF
--- a/mitreattack/attackToExcel/attackToExcel.py
+++ b/mitreattack/attackToExcel/attackToExcel.py
@@ -81,6 +81,51 @@ def get_stix_data(
     return mem_store
 
 
+def _build_dataframes_common(src: MemoryStore, domain: str, *, use_pre_v18_datasources: bool = False) -> Dict:
+    """Shared implementation for building pandas dataframes for each ATT&CK type.
+
+    Parameters
+    ----------
+    src : MemoryStore
+        MemoryStore or other stix2 DataSource object
+    domain : str
+        domain of ATT&CK src corresponds to, e.g "enterprise-attack"
+    use_pre_v18_datasources : bool
+        If True, uses the pre-v18 datasourcesToDf (combined data sources + components).
+        If False, uses the v18+ datacomponentsToDf.
+
+    Returns
+    -------
+    dict
+        A dict lookup of each ATT&CK type to dataframes for the given type to be ingested by write_excel
+    """
+    # Pre-compute all relationship data once (the expensive part) instead of
+    # repeating it 7+ times across the individual *ToDf() calls.
+    logger.info("Pre-computing relationship data...")
+    rel_data = stixToDf._process_all_relationships(src)
+
+    df = {
+        "techniques": stixToDf.techniquesToDf(src, domain, _rel_data=rel_data),
+        "tactics": stixToDf.tacticsToDf(src),
+        "software": stixToDf.softwareToDf(src, _rel_data=rel_data),
+        "groups": stixToDf.groupsToDf(src, _rel_data=rel_data),
+        "campaigns": stixToDf.campaignsToDf(src, _rel_data=rel_data),
+        "assets": stixToDf.assetsToDf(src, _rel_data=rel_data),
+        "mitigations": stixToDf.mitigationsToDf(src, _rel_data=rel_data),
+        "matrices": stixToDf.matricesToDf(src, domain),
+        "relationships": stixToDf.relationshipsToDf(src, _precomputed=rel_data),
+        "analytics": stixToDf.analyticsToDf(src),
+        "detectionstrategies": stixToDf.detectionstrategiesToDf(src),
+    }
+
+    if use_pre_v18_datasources:
+        df["datasources"] = stixToDf.datasourcesToDf(src, _rel_data=rel_data)
+    else:
+        df["datacomponents"] = stixToDf.datacomponentsToDf(src)
+
+    return df
+
+
 def build_dataframes_pre_v18(src: MemoryStore, domain: str) -> Dict:
     """Build pandas dataframes for each attack type, and return a dictionary lookup for each type to the relevant dataframe.
 
@@ -98,26 +143,7 @@ def build_dataframes_pre_v18(src: MemoryStore, domain: str) -> Dict:
     dict
         A dict lookup of each ATT&CK type to dataframes for the given type to be ingested by write_excel
     """
-    # Pre-compute all relationship data once (the expensive part) instead of
-    # repeating it 7+ times across the individual *ToDf() calls.
-    logger.info("Pre-computing relationship data...")
-    rel_data = stixToDf._process_all_relationships(src)
-
-    df = {
-        "techniques": stixToDf.techniquesToDf(src, domain, _rel_data=rel_data),
-        "tactics": stixToDf.tacticsToDf(src),
-        "software": stixToDf.softwareToDf(src, _rel_data=rel_data),
-        "groups": stixToDf.groupsToDf(src, _rel_data=rel_data),
-        "campaigns": stixToDf.campaignsToDf(src, _rel_data=rel_data),
-        "assets": stixToDf.assetsToDf(src, _rel_data=rel_data),
-        "mitigations": stixToDf.mitigationsToDf(src, _rel_data=rel_data),
-        "matrices": stixToDf.matricesToDf(src, domain),
-        "relationships": stixToDf.relationshipsToDf(src, _precomputed=rel_data),
-        "datasources": stixToDf.datasourcesToDf(src, _rel_data=rel_data),
-        "analytics": stixToDf.analyticsToDf(src),
-        "detectionstrategies": stixToDf.detectionstrategiesToDf(src),
-    }
-    return df
+    return _build_dataframes_common(src, domain, use_pre_v18_datasources=True)
 
 
 def build_dataframes(src: MemoryStore, domain: str) -> Dict:
@@ -135,26 +161,7 @@ def build_dataframes(src: MemoryStore, domain: str) -> Dict:
     dict
         A dict lookup of each ATT&CK type to dataframes for the given type to be ingested by write_excel
     """
-    # Pre-compute all relationship data once (the expensive part) instead of
-    # repeating it 7+ times across the individual *ToDf() calls.
-    logger.info("Pre-computing relationship data...")
-    rel_data = stixToDf._process_all_relationships(src)
-
-    df = {
-        "techniques": stixToDf.techniquesToDf(src, domain, _rel_data=rel_data),
-        "tactics": stixToDf.tacticsToDf(src),
-        "software": stixToDf.softwareToDf(src, _rel_data=rel_data),
-        "groups": stixToDf.groupsToDf(src, _rel_data=rel_data),
-        "campaigns": stixToDf.campaignsToDf(src, _rel_data=rel_data),
-        "assets": stixToDf.assetsToDf(src, _rel_data=rel_data),
-        "mitigations": stixToDf.mitigationsToDf(src, _rel_data=rel_data),
-        "matrices": stixToDf.matricesToDf(src, domain),
-        "relationships": stixToDf.relationshipsToDf(src, _precomputed=rel_data),
-        "datacomponents": stixToDf.datacomponentsToDf(src),
-        "analytics": stixToDf.analyticsToDf(src),
-        "detectionstrategies": stixToDf.detectionstrategiesToDf(src),
-    }
-    return df
+    return _build_dataframes_common(src, domain, use_pre_v18_datasources=False)
 
 
 def build_ds_an_lg_relationships(dataframes: Dict) -> Dict[str, pd.DataFrame]:

--- a/mitreattack/attackToExcel/attackToExcel.py
+++ b/mitreattack/attackToExcel/attackToExcel.py
@@ -98,17 +98,22 @@ def build_dataframes_pre_v18(src: MemoryStore, domain: str) -> Dict:
     dict
         A dict lookup of each ATT&CK type to dataframes for the given type to be ingested by write_excel
     """
+    # Pre-compute all relationship data once (the expensive part) instead of
+    # repeating it 7+ times across the individual *ToDf() calls.
+    logger.info("Pre-computing relationship data...")
+    rel_data = stixToDf._process_all_relationships(src)
+
     df = {
-        "techniques": stixToDf.techniquesToDf(src, domain),
+        "techniques": stixToDf.techniquesToDf(src, domain, _rel_data=rel_data),
         "tactics": stixToDf.tacticsToDf(src),
-        "software": stixToDf.softwareToDf(src),
-        "groups": stixToDf.groupsToDf(src),
-        "campaigns": stixToDf.campaignsToDf(src),
-        "assets": stixToDf.assetsToDf(src),
-        "mitigations": stixToDf.mitigationsToDf(src),
+        "software": stixToDf.softwareToDf(src, _rel_data=rel_data),
+        "groups": stixToDf.groupsToDf(src, _rel_data=rel_data),
+        "campaigns": stixToDf.campaignsToDf(src, _rel_data=rel_data),
+        "assets": stixToDf.assetsToDf(src, _rel_data=rel_data),
+        "mitigations": stixToDf.mitigationsToDf(src, _rel_data=rel_data),
         "matrices": stixToDf.matricesToDf(src, domain),
-        "relationships": stixToDf.relationshipsToDf(src),
-        "datasources": stixToDf.datasourcesToDf(src),
+        "relationships": stixToDf.relationshipsToDf(src, _precomputed=rel_data),
+        "datasources": stixToDf.datasourcesToDf(src, _rel_data=rel_data),
         "analytics": stixToDf.analyticsToDf(src),
         "detectionstrategies": stixToDf.detectionstrategiesToDf(src),
     }
@@ -130,16 +135,21 @@ def build_dataframes(src: MemoryStore, domain: str) -> Dict:
     dict
         A dict lookup of each ATT&CK type to dataframes for the given type to be ingested by write_excel
     """
+    # Pre-compute all relationship data once (the expensive part) instead of
+    # repeating it 7+ times across the individual *ToDf() calls.
+    logger.info("Pre-computing relationship data...")
+    rel_data = stixToDf._process_all_relationships(src)
+
     df = {
-        "techniques": stixToDf.techniquesToDf(src, domain),
+        "techniques": stixToDf.techniquesToDf(src, domain, _rel_data=rel_data),
         "tactics": stixToDf.tacticsToDf(src),
-        "software": stixToDf.softwareToDf(src),
-        "groups": stixToDf.groupsToDf(src),
-        "campaigns": stixToDf.campaignsToDf(src),
-        "assets": stixToDf.assetsToDf(src),
-        "mitigations": stixToDf.mitigationsToDf(src),
+        "software": stixToDf.softwareToDf(src, _rel_data=rel_data),
+        "groups": stixToDf.groupsToDf(src, _rel_data=rel_data),
+        "campaigns": stixToDf.campaignsToDf(src, _rel_data=rel_data),
+        "assets": stixToDf.assetsToDf(src, _rel_data=rel_data),
+        "mitigations": stixToDf.mitigationsToDf(src, _rel_data=rel_data),
         "matrices": stixToDf.matricesToDf(src, domain),
-        "relationships": stixToDf.relationshipsToDf(src),
+        "relationships": stixToDf.relationshipsToDf(src, _precomputed=rel_data),
         "datacomponents": stixToDf.datacomponentsToDf(src),
         "analytics": stixToDf.analyticsToDf(src),
         "detectionstrategies": stixToDf.detectionstrategiesToDf(src),

--- a/mitreattack/attackToExcel/stixToDf.py
+++ b/mitreattack/attackToExcel/stixToDf.py
@@ -1019,8 +1019,15 @@ class CellRange:
 
 
 def build_technique_and_sub_columns(
-    src, techniques, columns, merge_data_handle, matrix_grid_handle, tactic_name, platform=None,
-    *, _sub_techniques_store=None
+    src,
+    techniques,
+    columns,
+    merge_data_handle,
+    matrix_grid_handle,
+    tactic_name,
+    platform=None,
+    *,
+    _sub_techniques_store=None,
 ):
     """Build technique and subtechnique columns for a given matrix and attach them to the appropriate object listings.
 
@@ -1454,7 +1461,4 @@ def _get_relationship_citations(object_dataframe, relationship_df):
                 for cite in re.findall(r"\(Citation: (.*?)\)", desc):
                     id_to_citations.setdefault(obj_id, set()).add(cite)
 
-    return [
-        ",".join(f"(Citation: {c})" for c in id_to_citations.get(obj_id, set()))
-        for obj_id in all_ids
-    ]
+    return [",".join(f"(Citation: {c})" for c in id_to_citations.get(obj_id, set())) for obj_id in all_ids]

--- a/mitreattack/attackToExcel/stixToDf.py
+++ b/mitreattack/attackToExcel/stixToDf.py
@@ -12,7 +12,6 @@ from stix2 import Filter, MemoryStore
 from tqdm import tqdm
 
 from mitreattack.constants import MITRE_ATTACK_ID_SOURCE_NAMES, PLATFORMS_LOOKUP
-from mitreattack.stix20 import MitreAttackData
 
 # Module-level constants for type mappings (avoid recreating per call)
 _ATTACK_TO_STIX_TERM = {
@@ -1451,7 +1450,7 @@ def _get_relationship_citations(object_dataframe, relationship_df):
             # Use .isin() for batch filtering (single pass) instead of per-ID comparison
             mask = sheet_df[id_col].isin(id_set)
             matching = sheet_df.loc[mask, [id_col, "mapping description"]].dropna(subset=["mapping description"])
-            for obj_id, desc in zip(matching[id_col], matching["mapping description"]):
+            for obj_id, desc in zip(matching[id_col], matching["mapping description"], strict=True):
                 for cite in re.findall(r"\(Citation: (.*?)\)", desc):
                     id_to_citations.setdefault(obj_id, set()).add(cite)
 


### PR DESCRIPTION
The Excel export was extremely slow due to several N+1 query patterns
and redundant processing:

1. Process relationships once instead of 7-8 times: relationshipsToDf()
   was called independently for each object type (techniques, software,
   groups, campaigns, assets, mitigations, datasources), each time
   re-querying ALL relationships, re-fetching source/target objects, and
   re-creating MitreAttackData. Now the expensive processing happens once
   in _process_all_relationships() and the result is reused via the
   _precomputed parameter.

2. Eliminate redundant src.get() in relationship processing: The original
   code called src.get() 4 times per relationship (source, target, then
   get_attack_id re-fetched both). Now uses _extract_attack_id() on
   already-fetched objects and pre-builds an object cache for O(1) lookups.

3. Cache subtechnique-of queries in matrix processing:
   build_technique_and_sub_columns() re-queried subtechnique-of
   relationships on every call (~126 times for enterprise). Now queried
   once in matricesToDf() and passed via _sub_techniques_store parameter.

4. Cache data component lookups in analytics functions: analyticsToDf()
   and detectionStrategiesAnalyticsLogSourcesDf() called src.get() per
   log-source reference in nested loops. Now pre-fetches all data
   components into a dict before iteration.

5. Merge double iteration in analyticsToDf(): The validation pass and
   build pass are merged into a single loop, halving the iteration count.

6. Cache analytic lookups in detectionstrategiesToDf(): Pre-fetches all
   referenced analytics instead of per-detection-strategy src.get().

7. Optimize _get_relationship_citations(): Replaced O(n*m) 2D mask
   comparison with efficient .isin() batch filtering on ID columns.

All public API signatures are preserved via keyword-only arguments with
defaults, maintaining full backward compatibility.

https://claude.ai/code/session_01FkmWAqGAKMuPcBsZYURuaZ