### PR TITLE
fix(diffStix): write the changelog markdown as UTF-8

### DIFF
--- a/mitreattack/diffStix/changelog_helper.py
+++ b/mitreattack/diffStix/changelog_helper.py
@@ -2429,7 +2429,7 @@ def get_new_changelog_md(
     if markdown_file:
         logger.info("Writing markdown to file")
         Path(markdown_file).parent.mkdir(parents=True, exist_ok=True)
-        with open(markdown_file, "w") as file:
+        with open(markdown_file, "w", encoding="utf-8") as file:
             file.write(md_string)
 
     if html_file:

--- a/tests/changelog/integration/test_diffstix_output_encoding.py
+++ b/tests/changelog/integration/test_diffstix_output_encoding.py
@@ -1,0 +1,134 @@
+"""Integration test for the encoding of files written by get_new_changelog_md."""
+
+import json
+import subprocess
+import sys
+import textwrap
+
+IDENTITY = {
+    "type": "identity",
+    "id": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+    "spec_version": "2.1",
+    "name": "The MITRE Corporation",
+    "identity_class": "organization",
+    "created": "2017-06-01T00:00:00.000Z",
+    "modified": "2017-06-01T00:00:00.000Z",
+}
+
+MARKING = {
+    "type": "marking-definition",
+    "id": "marking-definition--fa42a846-8d90-4e51-bc29-71d5b4802168",
+    "spec_version": "2.1",
+    "created": "2017-06-01T00:00:00.000Z",
+    "definition_type": "statement",
+    "definition": {"statement": "Copyright 2017, MITRE."},
+}
+
+# Cyrillic and a Turkish dotted lowercase g, neither representable in cp1252 or
+# cp950. ATT&CK content does carry non-ASCII, notably in contributor names.
+NON_ASCII_NAME = "Обход контроля Türkçe"
+
+
+def _technique(name, attack_id, stix_id, created, modified):
+    return {
+        "type": "attack-pattern",
+        "id": stix_id,
+        "spec_version": "2.1",
+        "name": name,
+        "description": "test technique",
+        "created": created,
+        "modified": modified,
+        "x_mitre_version": "1.0",
+        "x_mitre_domains": ["enterprise-attack"],
+        "x_mitre_attack_spec_version": "3.2.0",
+        "created_by_ref": IDENTITY["id"],
+        "object_marking_refs": [MARKING["id"]],
+        "external_references": [
+            {
+                "source_name": "mitre-attack",
+                "external_id": attack_id,
+                "url": f"https://attack.mitre.org/techniques/{attack_id}",
+            }
+        ],
+    }
+
+
+def _write_bundles(tmp_path):
+    old_technique = _technique(
+        "Old Technique",
+        "T9999",
+        "attack-pattern--1f523a8f-a50f-490a-a0a3-48c8c1f889de",
+        "2023-01-01T00:00:00.000Z",
+        "2023-01-01T00:00:00.000Z",
+    )
+    added_technique = _technique(
+        NON_ASCII_NAME,
+        "T9998",
+        "attack-pattern--2f523a8f-a50f-490a-a0a3-48c8c1f889df",
+        "2023-06-01T00:00:00.000Z",
+        "2023-06-01T00:00:00.000Z",
+    )
+    for name, objects in [
+        ("old", [IDENTITY, MARKING, old_technique]),
+        ("new", [IDENTITY, MARKING, old_technique, added_technique]),
+    ]:
+        directory = tmp_path / name
+        directory.mkdir()
+        (directory / "enterprise-attack.json").write_text(
+            json.dumps({"type": "bundle", "id": f"bundle--{name}", "objects": objects}),
+            encoding="utf-8",
+        )
+    return tmp_path / "old", tmp_path / "new"
+
+
+def test_markdown_file_is_written_as_utf8(tmp_path):
+    """The markdown file must be UTF-8 regardless of the locale encoding.
+
+    Written as a subprocess under PEP 597 rather than a write-then-read-back
+    assertion. A round trip passes on an unfixed tree wherever the locale
+    encoding already is UTF-8, so on Linux CI it would go green either way and
+    pin nothing. `-X warn_default_encoding -W error::EncodingWarning` turns any
+    open() that relies on the locale codec into an error, so this fails on every
+    platform if the encoding argument goes missing again.
+
+    Only the markdown file is requested. The layer and JSON writers also open
+    without an encoding, but they emit through json.dump, whose ensure_ascii
+    default keeps their output ASCII, so they are a separate concern.
+    """
+    old_dir, new_dir = _write_bundles(tmp_path)
+    markdown_file = tmp_path / "changelog.md"
+
+    driver = tmp_path / "driver.py"
+    driver.write_text(
+        textwrap.dedent(
+            f"""
+            from mitreattack.diffStix.changelog_helper import get_new_changelog_md
+
+            get_new_changelog_md(
+                domains=["enterprise-attack"],
+                old={str(old_dir)!r},
+                new={str(new_dir)!r},
+                layers=[],
+                json_file=None,
+                markdown_file={str(markdown_file)!r},
+            )
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-X",
+            "warn_default_encoding",
+            "-W",
+            "error::EncodingWarning",
+            str(driver),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert NON_ASCII_NAME in markdown_file.read_text(encoding="utf-8")

--- a/tests/changelog/integration/test_diffstix_output_generation.py
+++ b/tests/changelog/integration/test_diffstix_output_generation.py
@@ -155,7 +155,7 @@ class TestDiffStixOutputGeneration:
         assert Path(layer_files[0]).exists()
 
         # Verify markdown file content
-        markdown_content = markdown_file.read_text()
+        markdown_content = markdown_file.read_text(encoding="utf-8")
         assert markdown_content == markdown_result
         assert "## Key" in markdown_content
 

--- a/tests/changelog/test_utils.py
+++ b/tests/changelog/test_utils.py
@@ -230,7 +230,7 @@ def validate_markdown_file_content(file_path: Union[str, Path]) -> str:
     path_obj = Path(file_path)
     assert path_obj.exists(), f"Markdown file should exist at {file_path}"
 
-    content = path_obj.read_text()
+    content = path_obj.read_text(encoding="utf-8")
     assert_basic_markdown_structure(content)
     return content
 
@@ -405,7 +405,7 @@ def validate_comprehensive_output_generation(
 
     # Validate markdown file content matches return value
     if "markdown" in file_paths:
-        file_content = Path(file_paths["markdown"]).read_text()
+        file_content = Path(file_paths["markdown"]).read_text(encoding="utf-8")
         assert file_content == markdown_result, "Markdown file content should match return value"
 
 


### PR DESCRIPTION
## What breaks

`get_new_changelog_md` opens the markdown file without an encoding, so CPython falls back to the locale codec. ATT&CK changelog text is not ASCII, so the write raises on any machine whose locale encoding is not UTF-8:

```
UnicodeEncodeError: 'cp950' codec can't encode character '\u041e' in position 238
  changelog_helper.py:2433 in get_new_changelog_md
```

Reproduced on Windows with a cp950 console. cp1252, the default on en-US Windows, fails the same way on Cyrillic. Linux and macOS default to UTF-8, which is why CI has never seen it.

The blast radius is larger than the one file. That write sits at the top of the output block in `get_new_changelog_md`, so the exception also skips the HTML writer, the detailed HTML writer, the layer writers and the JSON writer. A run ends with an empty markdown file and none of the other artifacts.

This looks like an oversight rather than a decision: the sibling writers in the same module already pass the encoding explicitly, at line 1849 and line 1955.

## The change

One argument at `changelog_helper.py:2432`:

```diff
-        with open(markdown_file, "w") as file:
+        with open(markdown_file, "w", encoding="utf-8") as file:
```

**The other bare opens in this module are deliberately left alone.** Lines 1861, 1866, 1871 and 2465 also open without an encoding, but they write through `json.dump`, whose `ensure_ascii` default keeps the payload ASCII, so they do not raise today. Happy to include them if you would rather the module be clean under `-X warn_default_encoding`, but they are a different question from this bug.

**Three `read_text()` calls in the tests get the matching encoding.** Before this change the round trip was symmetric by accident, locale-encoded at both ends. Once the writer is UTF-8, a reader that does not say so decodes with the locale codec, and `file_content == markdown_result` compares a mis-decoded string against the original. On my machine that turned two passing tests red, which is how I found them; on Linux CI they would have stayed green and the assertion would have quietly stopped meaning anything.

## About the test

It drives the writer in a subprocess under `-X warn_default_encoding -W error::EncodingWarning` rather than asserting on a round trip.

A round trip is the obvious test and it is useless here: it passes on an unfixed tree wherever the locale encoding is already UTF-8, so it would have gone green on your CI both before and after the fix. I checked that before writing this one. Under PEP 597 any `open()` that relies on the locale codec becomes an error, so the test fails on **every** platform if the encoding argument goes missing again, and the traceback names the exact line.

The driver passes `layers=[]` and `json_file=None` so only the markdown writer is exercised, keeping the assertion pointed at one thing.

## Verification

- New test: fails on unmodified `main`, passes with the fix. Confirmed in both directions by stashing the change and re-running.
- `tests/changelog`: 7 failures before this change and the same 7 after, none of them new. They are all in `cli/` and are pre-existing Windows environment assumptions, for example a `pytest.raises(PermissionError)` that Windows does not raise.
- `ruff check` and `ruff format --check` clean on all four touched files.